### PR TITLE
Add skipping non-required properties 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ var OpenAPISampler = require('openapi-sampler');
 A [OpenAPI Schema Object](http://swagger.io/specification/#schemaObject)
 - **options** (_optional_) - `object`
 Available options:
+  - **skipNonRequired** - `boolean`
+  Don't include non-required object properties not specified in [`required` property of the schema object](https://swagger.io/docs/specification/data-models/data-types/#required)
   - **skipReadOnly** - `boolean`
   Don't include `readOnly` object properties
   - **skipWriteOnly** - `boolean`

--- a/src/samplers/object.js
+++ b/src/samplers/object.js
@@ -2,7 +2,18 @@ import { traverse } from '../traverse';
 export function sampleObject(schema, options = {}, spec) {
   let res = {};
   if (schema && typeof schema.properties === 'object') {
+    let requiredKeys = (Array.isArray(schema.required) ? schema.required : []);
+    let requiredKeyDict = requiredKeys.reduce((dict, key) => {
+      dict[key] = true;
+      return dict;
+    }, {});
+
     Object.keys(schema.properties).forEach(propertyName => {
+      // skip before traverse that could be costly
+      if (options.skipNonRequired && !requiredKeyDict.hasOwnProperty(propertyName)) {
+        return;
+      }
+
       const sample = traverse(schema.properties[propertyName], options, spec);
       if (options.skipReadOnly && sample.readOnly) {
         return;

--- a/test/unit/object.spec.js
+++ b/test/unit/object.spec.js
@@ -77,4 +77,17 @@ describe('sampleObject', () => {
       property2: 'string'
     });
   });
+
+  it('should skip non-required properties if skipNonRequired=true', () => {
+    res = sampleObject({
+      properties: {
+        a: {type: 'string'},
+        b: {type: 'integer'}
+      },
+      required: ['a']
+    }, {skipNonRequired: true});
+    expect(res).to.deep.equal({
+      a: 'string'
+    });
+  });
 });


### PR DESCRIPTION
This PR adds `skipNonRequired` option, so one can configure whether non-required properties should be included in sampler object or not. 

I thinks this change is required to address https://github.com/Rebilly/ReDoc/issues/424